### PR TITLE
Fix Firebase messaging sender ID typo in env template

### DIFF
--- a/src/env.js.template
+++ b/src/env.js.template
@@ -4,7 +4,7 @@ module.exports = {
   firebaseApiKey: '',
   firebaseStorageBucket: '', // Not used currently
   firestoreURL: '',
-  firebsaeMessageSenderId: '', // Not used currently
+  firebaseMessageSenderId: '', // Not used currently
   authDomain: '',
   sentryDsn: ''
 }


### PR DESCRIPTION
## Summary
- correct `firebaseMessageSenderId` property in env template so Firebase config picks up messaging sender ID

## Testing
- `npm test --silent -- --watchAll=false` *(fails: INTERNAL ASSERTION FAILED: Expected a class definition)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d37aa2bc832091844988c0d48524